### PR TITLE
Switch to Sphinx logging API.

### DIFF
--- a/sphinxcontrib_github_alt.py
+++ b/sphinxcontrib_github_alt.py
@@ -18,6 +18,10 @@ __version__ = '1.0'
 from docutils import nodes, utils
 from docutils.parsers.rst.roles import set_classes
 
+from sphinx.util import logging
+logger = logging.getLogger(__name__)
+
+
 def make_link_node(rawtext, app, type, slug, options):
     """Create a link to a github resource.
 
@@ -73,7 +77,7 @@ def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]
     app = inliner.document.settings.env.app
-    #app.info('issue %r' % text)
+    # logger.info('issue %r' % text)
     if 'pull' in name.lower():
         category = 'pull'
     elif 'issue' in name.lower():
@@ -102,8 +106,7 @@ def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param options: Directive options for customization.
     :param content: The directive content for customization.
     """
-    app = inliner.document.settings.env.app
-    #app.info('user link %r' % text)
+    # logger.info('user link %r' % text)
     ref = 'https://www.github.com/' + text
     node = nodes.reference(rawtext, text, refuri=ref, **options)
     return [node], []
@@ -124,7 +127,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param content: The directive content for customization.
     """
     app = inliner.document.settings.env.app
-    #app.info('user link %r' % text)
+    # logger.info('user link %r' % text)
     try:
         base = app.config.github_project_url
         if not base:
@@ -144,7 +147,7 @@ def setup(app):
 
     :param app: Sphinx application context.
     """
-    app.info('Initializing GitHub plugin')
+    logger.info('Initializing GitHub plugin')
     app.add_role('ghissue', ghissue_role)
     app.add_role('ghpull', ghissue_role)
     app.add_role('ghuser', ghuser_role)


### PR DESCRIPTION
The currently-used API was deprecated in Sphinx 1.6 and removed entirely in 2.0.